### PR TITLE
feat: implement explicit buyer and seller profile creation

### DIFF
--- a/server/routers/listing.ts
+++ b/server/routers/listing.ts
@@ -5,7 +5,7 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { randomUUID } from "crypto";
-import { getOrCreateSeller } from "./utils";
+import { getSeller } from "./utils";
 
 
 const SizesEnum = z.enum(["S", "M", "L", "XL", "XXL", "XXXL"]);
@@ -109,7 +109,7 @@ export const listingRouter = createTRPCRouter({
       const userId = ctx.user?.id;
       if (!userId) throw new TRPCError({ code: "UNAUTHORIZED" });
       try {
-        const seller = await getOrCreateSeller(userId);
+        const seller = await getSeller(userId);
 
         // if limited supply, quantity must be provided and > 0
         if (
@@ -190,7 +190,7 @@ export const listingRouter = createTRPCRouter({
       const userId = ctx.user?.id;
       if (!userId) throw new TRPCError({ code: "UNAUTHORIZED" });
       try {
-        const seller = await getOrCreateSeller(userId);
+        const seller = await getSeller(userId);
 
         const [created] = await db
           .insert(listings)
@@ -228,7 +228,7 @@ export const listingRouter = createTRPCRouter({
       const userId = ctx.user?.id;
       if (!userId) throw new TRPCError({ code: "UNAUTHORIZED" });
       try {
-        const seller = await getOrCreateSeller(userId);
+        const seller = await getSeller(userId);
 
         const rows = await db
           .select()
@@ -272,7 +272,7 @@ export const listingRouter = createTRPCRouter({
       const userId = ctx.user?.id;
       if (!userId) throw new TRPCError({ code: "UNAUTHORIZED" });
       try {
-        const seller = await getOrCreateSeller(userId);
+        const seller = await getSeller(userId);
 
         const rows = await db
           .select({
@@ -334,7 +334,7 @@ export const listingRouter = createTRPCRouter({
       const userId = ctx.user?.id;
       if (!userId) throw new TRPCError({ code: "UNAUTHORIZED" });
       try {
-        const seller = await getOrCreateSeller(userId);
+        const seller = await getSeller(userId);
 
         const owned = await db
           .select()
@@ -380,7 +380,7 @@ export const listingRouter = createTRPCRouter({
       const userId = ctx.user?.id;
       if (!userId) throw new TRPCError({ code: "UNAUTHORIZED" });
       try {
-        const seller = await getOrCreateSeller(userId);
+        const seller = await getSeller(userId);
 
         const owned = await db
           .select()

--- a/server/routers/utils.ts
+++ b/server/routers/utils.ts
@@ -1,19 +1,19 @@
 import { db } from "../db";
 import { sellers } from "../db/schema";
 import { eq } from "drizzle-orm";
-import { randomUUID } from "crypto";
+import { TRPCError } from "@trpc/server";
 
 /**
- * Get or create a seller record for a given user ID.
+ * Get a seller record for a given user ID.
  * 
  * This function ensures that every user with the 'seller' role has a corresponding
- * seller record in the database. If the seller doesn't exist, it will be created automatically.
+ * seller record in the database.
  * 
- * @param userId - The user ID to get or create a seller for
+ * @param userId - The user ID to get a seller for
  * @returns The seller record
  * @throws Error if seller creation fails
  */
-export async function getOrCreateSeller(userId: string) {
+export async function getSeller(userId: string) {
   try {
     // Check if seller exists
     const existingSeller = await db
@@ -21,30 +21,19 @@ export async function getOrCreateSeller(userId: string) {
       .from(sellers)
       .where(eq(sellers.userId, userId));
 
-    if (existingSeller.length > 0) {
-      return existingSeller[0];
+    if (existingSeller.length === 0) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Seller profile not found. Please create a profile first.",
+      });
     }
 
-    // Create new seller
-    const sellerId = randomUUID();
-    await db.insert(sellers).values({
-      id: sellerId,
-      userId,
-    });
-
-    // Fetch newly created seller
-    const newSeller = await db
-      .select()
-      .from(sellers)
-      .where(eq(sellers.id, sellerId));
-
-    if (!newSeller[0]) {
-      throw new Error("Failed to create seller record");
-    }
-
-    return newSeller[0];
+    return existingSeller[0];
   } catch (err: any) {
-    console.error("Error in getOrCreateSeller:", err);
-    throw new Error(`getOrCreateSeller failed: ${err?.message || err}`);
+    console.error("Error in getSeller:", err);
+    if (err instanceof TRPCError) {
+      throw err;
+    }
+    throw new Error(`getSeller failed: ${err?.message || err}`);
   }
 }


### PR DESCRIPTION
this pr solve the implicit creation of buyers and seller profiles into and explicit actions 

the previous getOrCreateBuyer and getOrCreateSeller function wil automatically create a new profile if any those not exist when any related endpoint was accessed. this will lead to unintentional creation of account of user who did not choose any role and potential ghost account 

**changes** 

**- renamed `getOrCreateBuyer` to `getBuyer` in  `routers/buyer.ts` and `getOrCreateSeller` in` routers/utils.ts`**
this functions now strictly retrieve an existing profile 

**- introduced `createBuyerProfile` in routers/buyer.ts)and `createSellerProfile` in `routers/seller.ts`**
this new trpc are now the main entry point for creating buyers and seller profiles 
